### PR TITLE
CI best practices (use actions/cache for npm install cache)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,11 +11,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build
-        run: |
-          npm install
-          npm run build-web
-          
+      # Make use of npm install cache
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      # Install using ONLY the package-lock.json
+      - run: npm ci
+      # Run tests
+      - run: npm run build-web
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,9 +19,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       # Install using ONLY the package-lock.json
-      - run: npm ci
-      # Run tests
-      - run: npm run build-web
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build app
+        run: npm run build-web
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@
 
 name: CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   push:
     branches: [ main ]
@@ -23,9 +23,14 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-
-      # Runs a set of commands using the runners shell
-      - name: Run and test
-        run: |
-          npm install
-          npm test
+      # Cache the npm install cache
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      # Install using ONLY the package-lock.json
+      - run: npm ci
+      # Run tests
+      - run: npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       # Install using ONLY the package-lock.json
-      - run: npm ci
-      # Run tests
-      - run: npm test
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
Update the CI workflows to follow a couple best practices

- Use `npm ci`: This installs using _only_ `package-lock.json`, ensuring CI runs with the expected environment, doesn't upgrade packages, etc. More specifics available in the [npm docs](https://docs.npmjs.com/cli/v7/commands/npm-ci).
- Use `actions/cache` to save the `~/.npm` package cache. [docs](https://github.com/actions/cache/blob/main/examples.md#node---npm)
- Run distinct commands seperately (e.g. run an install phase **then** test phase. This can make debugging exactly which command failed slightly easier).

Additionally, here's an [example run](https://github.com/R167/chocopy-wasm-compiler/runs/1964134319?check_suite_focus=true) testing these changes.