### PR TITLE
add .toString() for Type

### DIFF
--- a/ast.ts
+++ b/ast.ts
@@ -1,11 +1,23 @@
 // import { TypeCheckError } from "./type-check";
 
+export class TaggedType<T extends string> {
+  tag: T;
+  constructor(tag: T) { this.tag = tag }
+  toString(): string { return this.tag }
+}
+
+export class ClassType extends TaggedType<"class"> {
+  name: string;
+  constructor(name: string) { super("class"); this.name = name }
+  toString() { return this.name }
+}
+
 // export enum Type {NUM, BOOL, NONE, OBJ}; 
 export type Type =
-  | {tag: "number"}
-  | {tag: "bool"}
-  | {tag: "none"}
-  | {tag: "class", name: string}
+  | TaggedType<"number">
+  | TaggedType<"bool">
+  | TaggedType<"none">
+  | ClassType
 
 export type Parameter<A> = { name: string, type: Type }
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,6 +1,7 @@
 
 import { assertTC, assertTCFail } from './utils.test';
-import { NUM, BOOL, NONE } from '../utils';
+import { NUM, BOOL, NONE, CLASS } from '../utils';
+import { expect } from 'chai';
 
 describe('tc', () => {
 
@@ -99,3 +100,15 @@ describe('tc', () => {
   c = C().new(3, 4)
   c.x`, NUM);
 });
+
+describe("type serialization", () => {
+  [NONE, NUM, BOOL].forEach((type) => {
+    it(`${type.tag} serializes to its name`, () => {
+      expect(type.toString()).to.eq(type.tag)
+    })
+  })
+
+  it("Serializes classes to their name", () => {
+    expect(CLASS("TestClass").toString()).to.eq("TestClass")
+  }) 
+})

--- a/type-check.ts
+++ b/type-check.ts
@@ -190,7 +190,7 @@ export function tcStmt(env : GlobalTypeEnv, locals : LocalTypeEnv, stmt : Stmt<n
         throw new TypeCheckError("cannot return outside of functions");
       const tRet = tcExpr(env, locals, stmt.value);
       if (!isAssignable(env, tRet.a, locals.expectedRet)) 
-        throw new TypeCheckError("expected return type `" + (locals.expectedRet as any).name + "`; got type `" + (tRet.a as any).name + "`");
+        throw new TypeCheckError("expected return type `" + locals.expectedRet + "`; got type `" + tRet.a + "`");
       return {a: tRet.a, tag: stmt.tag, value:tRet};
     case "while":
       var tCond = tcExpr(env, locals, stmt.cond);

--- a/utils.ts
+++ b/utils.ts
@@ -1,4 +1,4 @@
-import { Value, Type } from "./ast";
+import { Value, Type, TaggedType, ClassType } from "./ast";
 
 export function PyValue(typ: Type, result: number): Value {
   switch (typ.tag) {
@@ -30,7 +30,9 @@ export function PyNone(): Value {
   return { tag: "none" };
 }
 
-export const NUM : Type = {tag: "number"};
-export const BOOL : Type = {tag: "bool"};
-export const NONE : Type = {tag: "none"};
-export function CLASS(name : string) : Type {return {tag: "class", name}};
+export const NUM: Type = new TaggedType("number");
+export const BOOL: Type = new TaggedType("bool");
+export const NONE: Type = new TaggedType("none");
+export function CLASS(name: string): Type {
+  return new ClassType(name);
+}


### PR DESCRIPTION
Currently parts of the compiler that must report arbitrary type errors typically do so through string interpolation, such as in field assignment

https://github.com/ucsd-cse231-w21/chocopy-wasm-compiler/blob/ed7fd8a05306e3140afd97d9ac8bc81bc96eba43/type-check.ts#L214

As it currently stands, this will print type `[object Object]` when it tries to display the type. I propose adding a prototype to `Type`s which implements `toString()` and resolves this issue. This issue was additionally present in type checking return statements where we would blindly cast to `any` and try to access the `name` field (leading to error messages of "expected return type `undefined`; got type `undefined`" for functions like `def r(): return 5`)