### PR TITLE
Fix required else statement parsing

### DIFF
--- a/parser.ts
+++ b/parser.ts
@@ -284,7 +284,10 @@ export function traverseStmt(c : TreeCursor, s : string) : Stmt<null> {
       // console.log("Thn:", thn);
       c.parent();
       
-      c.nextSibling(); // Focus on else
+      if (!c.nextSibling() || c.name !== "else") {
+        // Focus on else
+        throw new Error("if statement missing else block");
+      }; 
       c.nextSibling(); // Focus on : els
       c.firstChild(); // Focus on :
       var els = [];

--- a/tests/pa3-visible.test.ts
+++ b/tests/pa3-visible.test.ts
@@ -203,4 +203,7 @@ else:
   c : C = None
   c = None`, PyNone());
 
+  assertFail("missing-else", `
+if True:
+  pass`)
 });


### PR DESCRIPTION
The parser seems to implement the PA3 grammar. This requires an else block for all if statements.

Example of program that currently returns unexpected output:

```python
if False:
  print(True)
```

Expected: ""
Got: "True"

This is because we advance the cursor to where we expect the else block to be. However, since we don't do any validation that it's actually progressed to the else block, so we end up processing the "then" block again for the "else" section.