### PR TITLE
Fix caching action so cypress binary is cached (consequence of Testing PR #5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,9 @@ jobs:
       # Make use of npm install cache
       - uses: actions/cache@v2
         with:
-          path: ~/.npm
+          path: |
+            ~/.npm
+            ~/.cache/Cypress
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,9 @@ jobs:
       # Cache the npm install cache
       - uses: actions/cache@v2
         with:
-          path: ~/.npm
+          path: |
+            ~/.npm
+            ~/.cache/Cypress
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-


### PR DESCRIPTION
In the Testing PR #5, Cypress was added as a dependency. This downloads and installs the cypress binary if it doesn't exist, or uses the cached version if it does. Add the cypress cache directory to speed up tests during the install phase (needing to reinstall cypress each time added ~30 seconds).

Docs on cypress cache location: https://docs.cypress.io/guides/getting-started/installing-cypress.html#Binary-cache
Example action run verifying that cypress correctly uses the cache to restore: https://github.com/R167/chocopy-wasm-compiler/runs/1992137958?check_suite_focus=true#step:4:11