### PR TITLE
BigInt type bug fix

### DIFF
--- a/ast.ts
+++ b/ast.ts
@@ -44,7 +44,7 @@ export type Expr<A> =
   | {  a?: A, tag: "block", block: Array<Stmt<A>>, expr: Expr<A> }
 
 export type Literal = 
-    { tag: "num", value: BigInt }
+    { tag: "num", value: bigint }
   | { tag: "bool", value: boolean }
   | { tag: "none" }
 


### PR DESCRIPTION
In typescript, the correct type declaration for BigInt values is actually 'bigint'. Interestingly, using 'BigInt' instead of 'bigint' seems to pass test cases and work correctly when run locally, but fails on the live project site.