### PR TITLE
Dictionary Mark-and-Sweep Tracing Fix

### DIFF
--- a/gc.ts
+++ b/gc.ts
@@ -502,7 +502,6 @@ export class MnS<A extends MarkableAllocator> {
         }
       } else if (childTag === TAG_OPAQUE) {
         // NOP
-      //
       } else {
         throw new Error(
           `Trying to trace unknown heap object: { addr=${childPtr}, tag=${(childTag as any).toString()}, size=${childSize} }`

--- a/tests/gc-int.test.ts
+++ b/tests/gc-int.test.ts
@@ -246,4 +246,20 @@ describe("GC-MnS Integration Tests", () => {
     PyInt(99),
     4n
   );
+
+  assertsUsage("Dictionary", [
+    [
+      `
+      d: [int, int] = None
+      d = {3:4}
+      `,
+      PyNone(),
+      52n,
+    ],
+    ["d[3]", PyInt(4), 52n],
+    ["d[9] = 19", PyNone(), 64n],
+    ["d[9]", PyInt(19), 64n],
+    ["d[13] = 1337", PyNone(), 76n],
+    ["d[13]", PyInt(1337), 76n],
+  ]);
 });

--- a/tests/gc-unit.test.ts
+++ b/tests/gc-unit.test.ts
@@ -181,11 +181,14 @@ describe("GC-MnS", () => {
       mns.roots.addLocal(0n, ptr0);
       mns.collect();
 
-      // ptr1 gets written at 1988
       const ptr1 = mns.gcalloc(TAG_DICT_ENTRY, 12n);
       expect(Number(ptr1)).to.equal(1940);
-      writeI32(memory, 1988, ptr1);
       const header1 = heap.mappedHeader(ptr1);
+
+      // Simulates inserting into the dictionary
+      // ptr1 gets written at 1988
+      writeI32(memory, 1988, ptr1);
+
       expectAllocatedHeader(header0, TAG_DICT, 40n);
       expectAllocatedHeader(header1, TAG_DICT_ENTRY, 12n);
       mns.markFromRoots();
@@ -196,8 +199,12 @@ describe("GC-MnS", () => {
       const ptr2 = mns.gcalloc(TAG_DICT_ENTRY, 12n);
       expect(Number(ptr2)).to.equal(1920);
       const header2 = heap.mappedHeader(ptr2);
-      mns.collect();
 
+      // Simulates inserting into the dictionary
+      // ptr2 gets written at 1996
+      writeI32(memory, 1996, ptr2);
+
+      mns.collect();
       expectAllocatedHeader(header0, TAG_DICT, 40n);
       expectAllocatedHeader(header1, TAG_DICT_ENTRY, 12n);
       expectAllocatedHeader(header2, TAG_DICT_ENTRY, 12n);


### PR DESCRIPTION
Dictionaries are arrays of POINTERS to dictionary entries, not an array of dictionary entries.

Add an integration REPL test and a simulated unit test.